### PR TITLE
chore: rename repo artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![license](https://img.shields.io/github/license/manoldonev/visualization-assignment?style=plastic) ![ci workflow](https://github.com/manoldonev/visualization-assignment/actions/workflows/main.yml/badge.svg) ![pnpm](https://img.shields.io/badge/maintained%20with-pnpm-f69203.svg?logo=pnpm)
+![license](https://img.shields.io/github/license/manoldonev/react-visualization-assignment-ts?style=plastic) ![ci workflow](https://github.com/manoldonev/react-visualization-assignment-ts/actions/workflows/main.yml/badge.svg) ![pnpm](https://img.shields.io/badge/maintained%20with-pnpm-f69203.svg?logo=pnpm)
 
-Latest deployment available at https://manoldonev.github.io/visualization-assignment/
+Latest deployment available at https://manoldonev.github.io/react-visualization-assignment-ts/
 
 # Visualization Assignment SPA
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "visualization-assignment",
-  "homepage": "https://manoldonev.github.io/visualization-assignment",
+  "name": "react-visualization-assignment-ts",
+  "homepage": "https://manoldonev.github.io/react-visualization-assignment-ts",
   "version": "0.4.0",
   "private": true,
   "dependencies": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import react from '@vitejs/plugin-react';
 // eslint-disable-next-line import/no-default-export
 export default defineConfig({
   plugins: [react(), tsConfigPaths()],
-  base: '/visualization-assignment/',
+  base: '/react-visualization-assignment-ts/',
   publicDir: './public',
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
Rename artifacts to match the new repo name (`visualization-assignment` -> `react-visualization-assignment-ts`).